### PR TITLE
default reload command to acme-reload (reload any webserver, extra lo…

### DIFF
--- a/acme-reload
+++ b/acme-reload
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+# Can add extra reload steps in /usr/local/sbin/acme-reload-extra
+[ -x /usr/local/sbin/acme-reload-extra ] && source /usr/local/sbin/acme-reload-extra
+
+# Reload any webserver if active
+for s in nginx apache2 haproxy; do
+    if systemctl is-active $s >/dev/null; then
+        echo "[$(date)] Reloading $s"
+        systemctl reload $s
+    fi
+done

--- a/acme.sh
+++ b/acme.sh
@@ -7212,7 +7212,7 @@ _process() {
   _key_file=""
   _ca_file=""
   _fullchain_file=""
-  _reloadcmd=""
+  _reloadcmd="/usr/bin/acme-reload"
   _password=""
   _accountconf=""
   _useragent=""

--- a/debian/install
+++ b/debian/install
@@ -1,4 +1,5 @@
 acme.sh      usr/bin
+acme-reload  usr/bin
 acme-wrapper usr/bin
 deploy/*     usr/share/acme/deploy
 dnsapi/*     usr/share/acme/dnsapi


### PR DESCRIPTION
Default reload command to /usr/bin/acme-reload, included in repo:
* reload any webserver active
* local extra script /usr/local/sbin/acme-reload-extra called if it exists

Tested with no `--reloadcmd`:

```
[...]
[Tue Jul  4 02:54:52 PM CEST 2023] Run reload cmd: /usr/bin/acme-reload
[Tue Jul  4 02:54:52 PM CEST 2023] Reloading apache2
[Tue Jul  4 02:54:52 PM CEST 2023] Reload success
```

and with `--reloadcmd /bin/true`:
```
[...]
[Tue Jul  4 02:58:16 PM CEST 2023] Run reload cmd: /bin/true
[Tue Jul  4 02:58:16 PM CEST 2023] Reload success
```